### PR TITLE
README.sokol-flex: add sokol-flex readme to outline origin of the branch

### DIFF
--- a/README.sokol-flex
+++ b/README.sokol-flex
@@ -1,0 +1,8 @@
+This file identifies the origin of this branch for the vendor kernel port to
+Sokol Flex OS. This kernel was fetched from:
+
+repo: https://source.codeaurora.org/external/autobsps32/linux
+branch: release/bsp33.0-5.10.109-rt
+hash: 0bace7fde5f54fbbc2e598eec7990fec42b22443
+
+The kernel version at the time of this fork was: 5.10.109


### PR DESCRIPTION
This creates the README.sokol-flex file to identify the repo/branch origin.
This should help for someone looking through to quickly refer to this.

JIRA: SB-20625

Signed-off-by: Arsalan H. Awan <Arsalan_Awan@mentor.com>